### PR TITLE
Add note on 10,000 line stdout limit on parse failure

### DIFF
--- a/docs/lab.md
+++ b/docs/lab.md
@@ -307,3 +307,7 @@ $ cd test-autograder && make clean && make
 ### Writeup directory
 The `hello/writeup` contains the detailed lab writeup, either html or pdf file, that students can download from the Autolab front end.
 
+## FAQ
+#### Why is Autolab not displaying my stdout output?
+Autolab always shows the stdout output of running make, even when the program crashed or timed out. However, when it does crash and the expected autoresult json string is not appended to the output, parsing of the last line will fail. If this happens, any stdout output that is longer than 10,000 lines will be discarded (Note that this limit does not apply when the autoresult json is valid).
+


### PR DESCRIPTION
Added a FAQ section in the guide to lab authors section.

Inform users that if the autoresult json string is not valid, any stdout that is longer than 10,000 will be completely discarded.