### PR TITLE
Prelimary fixes for documentation

### DIFF
--- a/docs/index.md
+++ b/docs/index.md
@@ -1,6 +1,6 @@
 # Welcome to the Autolab Docs
 
-Autolab is a course management platform that enables instructors to offer autograded programming assignments to their students. The two key  ideas in Autolab are *autograding* that is, programs evaluating other programs, and *scoreboards* that display the latest autograded scores for each student. Autolab also provides gradebooks, rosters, handins/handouts, lab writeups, code annotation, manual grading, late penalties, grace days, cheat checking, meetings, partners, and bulk emails.
+Autolab is a course management platform that enables instructors to offer autograded programming assignments to their students. The two key ideas in Autolab are _autograding_ that is, programs evaluating other programs, and _scoreboards_ that display the latest autograded scores for each student. Autolab also provides gradebooks, rosters, handins/handouts, lab writeups, code annotation, manual grading, late penalties, grace days, cheat checking, meetings, partners, and bulk emails.
 
 For information on how to use Autolab for your course see the [Guide for Instructors](/instructors). To learn how to write an autograded lab see the [Guide for Lab Authors](/lab).
 
@@ -11,6 +11,7 @@ Autolab consists of two services: (1) the Ruby on Rails frontend, and (2) [Tango
 Currently, we have support for installing Autolab on [AWS](#aws), [Ubuntu 14.04+](#ubuntu-1404), and [Mac OSX](#mac-osx-1011).
 
 ### AWS
+
 If you want to try Autolab or Tango without any installation, we have a pre-built AMI you can deploy on AWS' free tier. To deploy it, follow the official [EC2 Launch Instructions](https://aws.amazon.com/premiumsupport/knowledge-center/launch-instance-custom-ami/). Make sure that you
 
 1. Select 'Autolab vx.x.x' as the ami. You can find this in the community amis tab.
@@ -25,11 +26,11 @@ Once your EC2 Instance is up, you can ssh into it using `ssh -i <aws_key>.pem ub
 
 There are two ways to install Autolab on Ubuntu.
 
-**Option 1** 
+**Option 1**
 
 The recommended way is to use the [OneClick option](/one-click). This option uses Docker to provide a complete installation of the Autolab frontend and Tango, for either development or production. Because it provides things like integration with SSL certificates and mail services, this option is specially useful for installing on external services like Heroku, EC2, DigitalOcean, or other Ubuntu VPS providers.
 
-**Option 2**  
+**Option 2**
 
 Another option is to install the frontend and Tango manually, without using Docker. This gives you more control over the installation, but is only appropriate for advanced users with knowledge of the Unix command line, Rails, and Ruby Gems. To install the Autolab frontend in developer mode, run the following script:
 
@@ -43,27 +44,28 @@ When the script runs, you will be prompted for the `sudo` password and other con
 
 Follow the step-by-step instructions below:
 
-1. Install [rbenv](https://github.com/sstephenson/rbenv) (use the Basic GitHub Checkout method)
+1.  Install [rbenv](https://github.com/sstephenson/rbenv) (use the Basic GitHub Checkout method)
 
-2. Install [ruby-build](https://github.com/sstephenson/ruby-build) as an rbenv plugin:
-		
-		:::bash
-        git clone https://github.com/sstephenson/ruby-build.git ~/.rbenv/plugins/ruby-build
-   Restart your shell at this point in order to start using your newly installed rbenv
-   
-3. Clone the Autolab repo into home directory and enter it:
-        
+2.  Install [ruby-build](https://github.com/sstephenson/ruby-build) as an rbenv plugin:
+
         :::bash
-        cd
-        git clone https://github.com/autolab/Autolab.git && cd Autolab
-        
+        git clone https://github.com/sstephenson/ruby-build.git ~/.rbenv/plugins/ruby-build
 
-4. Install the correct version of ruby:
-        
+    Restart your shell at this point in order to start using your newly installed rbenv
+
+3.  Clone the Autolab repo into home directory and enter it:
+
+        :::bash
+        cd ~/
+        git clone https://github.com/autolab/Autolab.git && cd Autolab
+
+4.  Install the correct version of ruby:
+
         :::bash
         rbenv install $(cat .ruby-version)
-   At this point, confirm that `rbenv` is working (you might need to restart your shell):
-        
+
+    At this point, confirm that `rbenv` is working (you might need to restart your shell):
+
         :::bash
         $ which ruby
         ~/.rbenv/shims/ruby
@@ -71,52 +73,57 @@ Follow the step-by-step instructions below:
         $ which rake
         ~/.rbenv/shims/rake
 
-5. Install `bundler`:
-        
+5.  Install `bundler`:
+
         :::bash
         gem install bundler
         rbenv rehash
 
-6. Install the required gems (run the following commands in the cloned Autolab repo):
+6.  Install the required gems (run the following commands in the cloned Autolab repo):
 
         :::bash
         cd bin
         bundle install
-   Refer to the [FAQ](#faq) for issues installing gems
 
-7. Install one of two database options
+    Refer to the [FAQ](#faq) for issues installing gems
 
-    * [SQLite](https://www.tutorialspoint.com/sqlite/sqlite_installation.htm) should **only** be used in development
-    * [MySQL](https://dev.mysql.com/doc/refman/5.7/en/osx-installation-pkg.html) can be used in development or production
+7.  Install one of two database options
 
-8. Configure your database:
-      
+    -   [SQLite](https://www.tutorialspoint.com/sqlite/sqlite_installation.htm) should **only** be used in development
+    -   [MySQL](https://dev.mysql.com/doc/refman/5.7/en/osx-installation-pkg.html) can be used in development or production
+
+8.  Configure your database:
+
         :::bash
         cp config/database.yml.template config/database.yml
-   Edit `database.yml` with the correct credentials for your chosen database. Refer to the [FAQ](#faq) for any issues.
 
-9. Configure school/organization specific information (new feature):
-        
+    Edit `database.yml` with the correct credentials for your chosen database. Refer to the [FAQ](#faq) for any issues.
+
+9.  Configure school/organization specific information (new feature):
+
         :::bash
         cp config/school.yml.template config/school.yml
+
     Edit `school.yml` with your school/organization specific names and emails
-    
-10. Configure the Devise Auth System with a unique key (run these commands exactly):
+
+10. Configure the Devise Auth System with a unique key (run these commands exactly - leave `<YOUR-SECRET-KEY>` as it is):
 
         :::bash
         cp config/initializers/devise.rb.template config/initializers/devise.rb
-        sed -i "s/<YOUR-SECRET-KEY>/`bundle exec rake secret`/g" initializers/devise.rb
-   Fill in `<YOUR_WEBSITE>` in `config/initializers/devise.rb` file. To skip this step for now, fill with `foo.bar`.
+        sed -i "s/<YOUR-SECRET-KEY>/`bundle exec rake secret`/g" config/initializers/devise.rb
+
+    Fill in `<YOUR_WEBSITE>` in the `config/initializers/devise.rb` file. To skip this step for now, fill with `foo.bar`.
 
 11. Create and initialize the database tables:
 
         :::bash
         bundle exec rake db:create
-	bundle exec rake db:migrate
+        bundle exec rake db:migrate
+
     Do not forget to use `bundle exec` in front of every rake/rails command.
 
 12. Populate dummy data (development only):
-        
+
         :::bash
         bundle exec rake autolab:populate
 
@@ -126,51 +133,58 @@ Follow the step-by-step instructions below:
         bundle exec rails s -p 3000
 
 14. Go to localhost:3000 and login with `Developer Login`:
-      
+
         :::bash
         Email: "admin@foo.bar".
 
 15. Install [Tango](/tango), the backend autograding service.
 
 16. Now you are all set to start using Autolab! Visit the [Guide for Instructors](/instructors) and [Guide for Lab Authors](/lab) pages for more info.
- 
+
 ## FAQ
 
 This is a general list of questions that we get often. If you find a solution to an issue not mentioned here,
 please contact us at <autolab-dev@andrew.cmu.edu>
 
-####Ubuntu Script Bugs
-If you get the following error
-```bash
-Failed to fetch http://dl.google.com/linux/chrome/deb/dists/stable/Release  
-Unable to find expected entry 'main/binary-i386/Packages' in Release file (Wrong sources.list entry or malformed file)
-``` 
-then follow the solution in [this post](http://askubuntu.com/questions/743814/unable-to-find-expected-entry-main-binary-i386-packages-chrome). 
+#### Ubuntu Script Bugs
 
-####Where do I find the MySQL username and password?
+If you get the following error
+
+```bash
+Failed to fetch http://dl.google.com/linux/chrome/deb/dists/stable/Release
+Unable to find expected entry 'main/binary-i386/Packages' in Release file (Wrong sources.list entry or malformed file)
+```
+
+then follow the solution in [this post](http://askubuntu.com/questions/743814/unable-to-find-expected-entry-main-binary-i386-packages-chrome).
+
+#### Where do I find the MySQL username and password?
 If this is your first time logging into MySQL, your username is 'root'. You may also need to set the root password:
 
 Start the server:
+
 ```bash
 sudo /usr/local/mysql/support-files/mysql.server start
 ```
 
 Set the password:
+
 ```bash
 mysqladmin -u root password "[New_Password]"
 ```
 
 If you lost your root password, refer to the [MySQL wiki](http://dev.mysql.com/doc/refman/5.7/en/resetting-permissions.html)
 
-####Bundle Install Errors
+#### Bundle Install Errors
 This happens as gems get updated. These fixes are gem-specific, but two common ones are
 
 `eventmachine`
+
 ```bash
 bundle config build.eventmachine --with-cppflags=-I/usr/local/opt/openssl/include
 ```
 
 `libv8`
+
 ```bash
 bundle config build.libv8 --with-system-v8
 ```
@@ -179,13 +193,13 @@ Run `bundle install` again
 
 If this still does not work, try exploring [this StackOverflow link](http://stackoverflow.com/questions/23536893/therubyracer-gemextbuilderror-error-failed-to-build-gem-native-extension)
 
-####Can't connect to local MySQL server through socket
+#### Can't connect to local MySQL server through socket
 Make sure you've started the MySQL server and double-check the socket in `config/database.yml`
 
 The default socket location is `/tmp/mysql.sock`.
 
 #### I forgot my MySQL root password
+
 You can reset it following the instructions on [this Stack Overflow post](http://stackoverflow.com/questions/6474775/setting-the-mysql-root-user-password-on-os-x)
 
 If `mysql` complains that the password is expired, follow the instructions on the second answer on [this post](http://stackoverflow.com/questions/33326065/unable-to-access-mysql-after-it-automatically-generated-a-temporary-password)
-

--- a/docs/instructors.md
+++ b/docs/instructors.md
@@ -1,94 +1,94 @@
 # Guide for Instructors
-This document provides instructors with a brief overview of the basic ideas and capabilities of the Autolab system. It's meant to be read from beginning to end the first time. 
+
+This document provides instructors with a brief overview of the basic ideas and capabilities of the Autolab system. It's meant to be read from beginning to end the first time.
 
 ## Users
-<i>Users</i> are either <i>instructors</i>, <i>course assistants</i>, or <i>students</i>. Instructors have full permissions. Course assistants are only allowed to enter grades. Students see only their own work. Each user is uniquely identified by their email address. You can change the permissions for a particular user at any time. Note that some instructors opt to give some or all of their TAs instructor status.
+
+_Users_ are either _instructors_, _course assistants_, or _students_. Instructors have full permissions. Course assistants are only allowed to enter grades. Students see only their own work. Each user is uniquely identified by their email address. You can change the permissions for a particular user at any time. Note that some instructors opt to give some or all of their TAs instructor status.
 
 ## Roster
-The <i>roster</i> holds the list of users. You can add and remove users one at a time, or in bulk by uploading a CSV file in the general Autolab format:
-<pre>
-Semester,email,last_name,first_name,school,major,year,grading_policy,courseNumber,courseLecture,section
-</pre>
+
+The _roster_ holds the list of users. You can add and remove users one at a time, or in bulk by uploading a CSV file in the general Autolab format:
+
+    Semester,email,last_name,first_name,school,major,year,grading_policy,courseNumber,courseLecture,section
+
 or in the format that is exported by the CMU S3 service:
-<pre>
-"Semester","Course","Section","Lecture","Mini","Last Name","First Name","MI","AndrewID","Email","College","Department",...
-</pre>
+
+    "Semester","Course","Section","Lecture","Mini","Last Name","First Name","MI","AndrewID","Email","College","Department",...
 
 !!! warning "Attention CMU Instructors:"
     S3 lists each student twice: once in a lecture roster, which lists the lecture number (e.g., 1, 2,...) in the section field, and once in a section roster, which lists the section letter (e.g., A, B,...) in the section field. Be careful not to import the lecture roster. Instead, export and upload each section individually. Or you can export everything from S3 with a single action, edit out the roster entries for the lecture(s), and then upload a single file to Autolab with all of the sections.
 
-For the bulk upload, you can choose to either: 
-<ol>
-<li> <b>add</b> any new students in the roster file to the Autolab roster, or to </li>
-<li> <b>update</b> the Autolab roster by marking students missing from roster files as <i>dropped</i>.</li> 
-</ol>
+For the bulk upload, you can choose to either:
 
-Instructors and course assistants are never marked as dropped. User accounts are never deleted. Students marked as dropped can still see their work, but cannot submit new work and do not appear on the instructor gradebook. Instructors can change the dropped status of a student at any time. 
+1. **add** any new students in the roster file to the Autolab roster, or to
+
+2. **update** the Autolab roster by marking students missing from roster files as _dropped_.
+
+Instructors and course assistants are never marked as dropped. User accounts are never deleted. Students marked as dropped can still see their work, but cannot submit new work and do not appear on the instructor gradebook. Instructors can change the dropped status of a student at any time.
 
 Once a student is added to the roster for a course, then that course becomes visible to the student when they visit the Autolab site. A student can be enrolled in an arbitrary number of Autolab courses.
 
 ## Labs (Assessments)
-A <i>lab</i> (or <i>assessment</i>) 
-is broadly defined as a submission set; it is anything that
-your students make submissions (handins) for. This could be a programming assignment, a
-typed homework, or even an in-class exam. You can create labs from scratch, or reuse them from previous semesters.
-See the companion [Guide For Lab Authors](/lab) for info on writing and installing labs. </p>
+
+A _lab_ (or _assessment_) is broadly defined as a submission set; it is anything that your students make submissions (handins) for. This could be a programming assignment, a typed homework, or even an in-class exam. You can create labs from scratch, or reuse them from previous semesters. See the companion [Guide For Lab Authors](/lab) for info on writing and installing labs.
 
 ## Assessment Categories
-You can tag each assessment with an arbitrary user-defined <i>category</i>, e.g., "Lab", "Exam", "Homework".
+
+You can tag each assessment with an arbitrary user-defined _category_, e.g., "Lab", "Exam", "Homework".
 
 ## Autograders and Scoreboards
-Labs can be <i>autograded</i> or not, at your disrcretion. When a student submits to an autograded lab, Autolab runs an instructor-supplied <i>autograder</i> program that assigns scores to one or more problems associated with the lab. Autograded labs can have an optional <i>scoreboard</i> that shows (anonymized) results in real-time. See the companion [Guide For Lab Authors](/lab) for details on writing autograded labs with scoreboards.
+
+Labs can be _autograded_ or not, at your disrcretion. When a student submits to an autograded lab, Autolab runs an instructor-supplied _autograder_ program that assigns scores to one or more problems associated with the lab. Autograded labs can have an optional _scoreboard_ that shows (anonymized) results in real-time. See the companion [Guide For Lab Authors](/lab) for details on writing autograded labs with scoreboards.
 
 ## Important Dates
-A lab has a <i>start date</i>, <i>due date</i>, <i>end date</i> and <i>grading deadline</i>. The link to a lab becomes visible to students after the start date (it's always visible to instructors). Students can submit until the due date without penalty or consuming grace days. Submission is turned off after the end date. Grades are included in the gradebook's category and course averages only after the grading deadline.
+
+A lab has a _start date_, _due date_, _end date_ and _grading deadline_. The link to a lab becomes visible to students after the start date (it's always visible to instructors). Students can submit until the due date without penalty or consuming grace days. Submission is turned off after the end date. Grades are included in the gradebook's category and course averages only after the grading deadline.
 
 ## Handins
+
 Once an assessment is live (past the start date), students can begin submitting handins, where each handin is a single file, which can be either a text file or an archive file (e.g., `mm.c`, `handin.tar`).
 
 ## Penalties and Extensions
-You can set penalties for late handins, set hard limits on the number of handins, or set soft limits that penalize excessive handins on a sliding scale. You can also give a student an <i>extension</i> that
+
+You can set penalties for late handins, set hard limits on the number of handins, or set soft limits that penalize excessive handins on a sliding scale. You can also give a student an _extension_ that
 extends the due dates and end dates for that student.
 
 ## Grace Days
-Autolab provides support for a late handin policy based on <i>grace days</i>. Each
+
+Autolab provides support for a late handin policy based on _grace days_. Each
 student has a semester-long budget of grace days that are automatically applied if they handin after the due date.
 Each late day consumes one of the budgeted grace days. The Autolab system keeps track of the number of grace days that have been used by each student to date. If students run out of grace days and handin late, then there
 is a fixed late penalty (possibly zero) that can be set by the instructor.
 
 ## Problems
-Each lab contains at least one <i>problem</i>, defined by the instructor, with some point value. Each problem has a name (e.g., "Prob1", "Style") that is unique for the lab (although different labs can have the same problem names).
+
+Each lab contains at least one _problem_, defined by the instructor, with some point value. Each problem has a name (e.g., "Prob1", "Style") that is unique for the lab (although different labs can have the same problem names).
 
 ## Submissions
-Once an assessment is live (past the start date), students can begin making submissions (handins),  where each submission is a single file.
+
+Once an assessment is live (past the start date), students can begin making submissions (handins), where each submission is a single file.
 
 ## Grades
-<i>Grades</i> come in a number of different forms:
-<ul>
-<li><i>Problem scores:</i> These are scalar values (possibly negative) assigned per problem per submission, either manually by a human grader after the end date, or automatically by an autograder after each submission. Problem scores can also be uploaded (imported) in bulk from a CSV file. </li>
 
-<li><i>Assessment raw score:</i> By default, the raw score is the sum of the individual problem scores, before 
-any penalties are applied. You can override the default raw score calculation. See below.</li>
+_Grades_ come in a number of different forms:
 
-<li><i>Assessment total score:</i> The total score is the raw score, plus any late penalties, plus any instructor <i>tweaks</i>.</li>
+1. _Problem scores:_ These are scalar values (possibly negative) assigned per problem per submission, either manually by a human grader after the end date, or automatically by an autograder after each submission. Problem scores can also be uploaded (imported) in bulk from a CSV file.
 
-<li><i>Category averages:</i> This is the average for a particular student over all
-assessments in a specific instructor-defined category such as "Labs, or "Exams".
-By default the category average is the arithmetic mean of all assessment total scores, but it can be overwridden.
-See below.</li>
+2. _Assessment raw score:_ By default, the raw score is the sum of the individual problem scores, before any penalties are applied. You can override the default raw score calculation. See below.
 
-<li><i>Course Average:</i> By default, the course average is average of all category averages, but can be overidden.
-See below.</li>
-</ul>
+3. _Assessment total score:_ The total score is the raw score, plus any late penalties, plus any instructor _tweaks_.
 
-Submissions can be
-classified as one of three types: "Normal", "No Grade" or "Excused". A "No
-Grade" submission will show up in the gradebook as NG and a zero will be used
-when calculating averages. An "Excused" submission will show up in the
-gradebook as EXC and will not be used when calculating averages.
+4. _Category averages:_ This is the average for a particular student over all assessments in a specific instructor-defined category such as "Labs, or "Exams". By default the category average is the arithmetic mean of all assessment total scores, but it can be overwridden. See below.
+
+5. _Course Average:_ By default, the course average is average of all category averages, but can be overidden. See below.
+
+Submissions can be classified as one of three types: "Normal", "No Grade" or "Excused". A "No Grade" submission will show up in the gradebook as NG and a zero will be used when calculating averages. An "Excused" submission will show up in the gradebook as EXC and will not be used when calculating averages.
 
 ## Overriding Raw Score Calculations
+
 Autolab computes raw scores for a lab with a Ruby function called `raw_score`. The default is the sum of the individual problem scores. But you can change this by providing your own `raw_score` function in `<labname>.rb` file. For example, to override the raw_score calculation for a lab called `malloclab`, you might add the following `raw_score` function to `malloclab/malloclab.rb`:
+
 ```ruby
   # In malloclab/malloclab.rb file
   def raw_score(score)
@@ -98,34 +98,35 @@ Autolab computes raw scores for a lab with a Ruby function called `raw_score`. T
     deduct = score["CorrectnessDeductions"].to_f()
     perfpoints = perfindex
 
-    # perfindex below 50 gets autograded score of 0. 
+    # perfindex below 50 gets autograded score of 0.
     if perfindex < 50.0 then
       perfpoints = 0
     else
       perfpoints = perfindex
     end
-    
+
     return perfpoints + heap + style + deduct
   end
 ```
 
-This particular lab has four problems called "Autograded Score",  "Heap Checker", "Style", and "CorrectnessDeductions". An "Autograded Score" less than 50 is set to zero when the raw score is calculated. 
+This particular lab has four problems called "Autograded Score", "Heap Checker", "Style", and "CorrectnessDeductions". An "Autograded Score" less than 50 is set to zero when the raw score is calculated.
 
 Note: To make this change live, you must select the "Reload config file" option on the `malloclab` page.
 
 ## Overriding Category and Course Averages
+
 The average for a category `foo` is calculated by a default Ruby function called `fooAverage`, which you can override in the `course.rb` file. For example, in our course, we prefer to report the "average" as the total number of normalized points (out of 100) that the student has accrued so far. This helps them understand where they stand in the class, e.g., "Going into the final exam (worth 30 normalized points), I have 60 normalized points, so the only way to get an A is to get 100% on the final." Here's the Ruby function for category "Lab":
 
 ```ruby
 # In course.rb file
 def LabAverage(user)
     pts = (user['datalab'].to_f() / 63.0) * 6.0 +
-	  (user['bomblab'].to_f() / 70.0) * 5.0 + 
+	  (user['bomblab'].to_f() / 70.0) * 5.0 +
 	  (user['attacklab'].to_f() / 100.0) * 4.0 +
 	  (user['cachelab'].to_f() / 60.0) * 7.0 +
 	  (user['tshlab'].to_f() / 110.0) * 8.0 +
 	  (user['malloclab'].to_f() / 120.0) * 12.0 +
-	  (user['proxylab'].to_f() / 100.0) * 8.0 
+	  (user['proxylab'].to_f() / 100.0) * 8.0
     return pts.to_f().round(2)
 end
 ```
@@ -133,18 +134,20 @@ end
 In this case, labs are worth a total of 50/100 normalized points. The assessment called `datalab` is graded out of a total of 63 points and is worth 6/50 normalized points.
 
 Here is the Ruby function for category "Exam":
+
 ```ruby
 # In course.rb file
-def ExamAverage(user) 
+def ExamAverage(user)
     pts = ((user['midterm'].to_f()/60.0) * 20.0) +
-          ((user['final'].to_f()/80.0)* 30.0) 
-    return pts.to_f().round(2) 
+          ((user['final'].to_f()/80.0)* 30.0)
+    return pts.to_f().round(2)
 end
 ```
 
 In this case, exams are worth 50/100 normalized points. The assessment called `midterm` is graded out of total of 60 points and is worth 20/50 normalized points.
 
 The course average is computed by a default Ruby function called `courseAverage`, which can be overridden by the `course.rb` file in the course directory. Here is the function for our running example:
+
 ```ruby
 # In course.rb file
 def courseAverage(user)
@@ -158,29 +161,27 @@ In this course, the course average is the sum of the category averages for "Lab"
 Note: To make these changes live, you must select "Reload course config file" on the "Manage course" page.
 
 ## Handin History
-For each lab, students can view all of their submissions, including any source code, and the problem scores, penalties, and total scores associated with those submissions, via the <i>handin history</i> page.
+
+For each lab, students can view all of their submissions, including any source code, and the problem scores, penalties, and total scores associated with those submissions, via the _handin history_ page.
 
 ## Gradesheet
-The <i>gradesheet</i> (not to be confused with the <i>gradebook</i>) is the workhorse grading tool. Each assessment has a separate gradesheet with the following features:
-<ul>
-<li>Provides an interface for manually entering problem scores (and problem feedback) for the most recent submmission from each student. </li>
-<li>Provides an interface for viewing and annotating the submitted code.</li>
-<li>Displays the problem scores for the most recent submission for each student, summarizes any late penalties, and computes the total score.</li>
-<li>Provides a link to each student's handin history.</li>
-</ul>
+
+The _gradesheet_ (not to be confused with the _gradebook_) is the workhorse grading tool. Each assessment has a separate gradesheet with the following features:
+
+-   Provides an interface for manually entering problem scores (and problem feedback) for the most recent submmission from each student.
+
+-   Provides an interface for viewing and annotating the submitted code.
+
+-   Displays the problem scores for the most recent submission for each student, summarizes any late penalties, and computes the total score.
+
+-   Provides a link to each student's handin history.
 
 ## Gradebook
-The <i>gradebook</i> comes in two forms. The <i>student gradebook</i> displays the 
-grades for a particular student, including total scores for each assessment, category averages, and the course average. The <i>instructor gradebook</i> is a table that displays the grades for the most recent submission of each student, including assessment total scores, category averages and course average. 
 
-For the gradebook calculations, submissions are 
-classified as one of three types: "Normal", "No Grade" or "Excused". A "No
-Grade" submission will show up in the gradebook as NG and a zero will be used
-when calculating averages. An "Excused" submission will show up in the
-gradebook as EXC and will not be used when calculating averages.
+The _gradebook_ comes in two forms. The _student gradebook_ displays the grades for a particular student, including total scores for each assessment, category averages, and the course average. The _instructor gradebook_ is a table that displays the grades for the most recent submission of each student, including assessment total scores, category averages and course average.
+
+For the gradebook calculations, submissions are classified as one of three types: "Normal", "No Grade" or "Excused". A "No Grade" submission will show up in the gradebook as NG and a zero will be used when calculating averages. An "Excused" submission will show up in the gradebook as EXC and will not be used when calculating averages.
 
 ## Releasing Grades
-Manually assigned grades are by default not released, and therefore not visible to
-students. You can release grades on an individual basis while grading, or
-release all available grades in bulk by using the "Release all grades" option. You can also reverse this
-process using the "Withdraw all grades" option. (The word "withdraw" is perhaps unfortunate. No grades are ever deleted. They are simply withdrawn from the student's view.)
+
+Manually assigned grades are by default not released, and therefore not visible to students. You can release grades on an individual basis while grading, or release all available grades in bulk by using the "Release all grades" option. You can also reverse this process using the "Withdraw all grades" option. (The word "withdraw" is perhaps unfortunate. No grades are ever deleted. They are simply withdrawn from the student's view.)

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -1,5 +1,5 @@
 site_name: Autolab Documentation
-pages:
+nav:
     - Autolab:
         - Getting Started: index.md
         - Guide for Instructors: instructors.md
@@ -17,15 +17,15 @@ pages:
         - VMMS Docs: tango-vmms.md
         - Deploying Tango: tango-deploy.md
     - OneClick Install: one-click.md
-theme: null
-theme_dir: 'mkdocs-material/material'
+theme:
+    name: material
+    palette:
+        primary: 'red'
+        accent: 'blue'
+    logo: 'images/logo.svg'
 repo_name: 'Autolab'
 repo_url: 'https://github.com/Autolab/autolab'
 extra:
-  logo: 'images/logo.svg'
-  palette:
-     primary: 'red'
-     accent: 'blue'
   social:
     - type: 'github'
       link: 'https://github.com/Autolab'
@@ -36,5 +36,6 @@ google_analytics:
   - 'auto'
 markdown_extensions:
   - admonition
-  - codehilite(linenums=true)
+  - codehilite
+      #linenums: true
 strict: true


### PR DESCRIPTION
This is the beginning of my fixes for documentation:

1. Fixed `mkdocs.yml` to work with the latest version of `mkdocs`

2. Prettify 2 Markdown files to actually be proper Markdown (i.e. avoid HTML as much as possible). Turns out the `bundle exec rake db:migrate` command I was referring to was in the file all along - it just wasn't being formatted properly because the Markdown formatting wasn't so good and thus I didn't see it

More to come, but feel free to merge this PR first and get this site to prod